### PR TITLE
Clean AndroidManifest attributes

### DIFF
--- a/mjpegviewer/src/main/AndroidManifest.xml
+++ b/mjpegviewer/src/main/AndroidManifest.xml
@@ -1,8 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.longdo.mjpegviewer">
-
-    <application android:allowBackup="true" android:label="@string/app_name">
-
-    </application>
-
-</manifest>
+<manifest package="com.longdo.mjpegviewer" />


### PR DESCRIPTION
The library declares attributes that are merged with the client application's manifest. They clash with whatever the developer decided to put.

In my case, the application's name string is called `live_app_name`. And when including the library, I get an error

```
Manifest merger failed : Attribute application@label value=(@string/live_app_name) from AndroidManifest.xml:9:9-46
        is also present at [com.github.perthcpe23:android-mjpeg-view:v1.0.9] AndroidManifest.xml:13:9-41 value=(@string/app_name).
```

Same thing for `allowBackup`. It is not up to the _android-mjpeg-view_ library to decide whether I should allow backups.

This PR removes those attributes.